### PR TITLE
Icon a11y

### DIFF
--- a/components/card_details.js
+++ b/components/card_details.js
@@ -63,7 +63,7 @@ const CardDetails = ({ summary, children, ...props }) => (
     <StyledSummary>
       <div>{summary}</div>
       <div css={flex2}>
-        <ExpandMore css="icon" />
+        <ExpandMore className="icon" />
       </div>
     </StyledSummary>
     <DetailsText>{children}</DetailsText>

--- a/components/vac_footer_en.js
+++ b/components/vac_footer_en.js
@@ -66,7 +66,7 @@ class VacFooterEn extends Component {
                         focusable="false"
                         data-prefix="fas"
                         data-icon="share-alt"
-                        role="img"
+                        role="presentation"
                         xmlns="http://www.w3.org/2000/svg"
                         viewBox="0 0 448 512"
                         data-fa-i2svg=""

--- a/components/vac_footer_fr.js
+++ b/components/vac_footer_fr.js
@@ -68,7 +68,7 @@ class VacFooterFr extends Component {
                         focusable="false"
                         data-prefix="fas"
                         data-icon="share-alt"
-                        role="img"
+                        role="presentation"
                         xmlns="http://www.w3.org/2000/svg"
                         viewBox="0 0 448 512"
                         data-fa-i2svg=""


### PR DESCRIPTION
When merged into VAC repo this will close #2032.

I fixed an unrelated issue where the chevron on the card_details wasn't rotating. I couldn't find the fa-angle-right icon in our app so I'm not sure if that is a real issue.